### PR TITLE
Add weekly review feature

### DIFF
--- a/lib/app/view/app.dart
+++ b/lib/app/view/app.dart
@@ -11,11 +11,13 @@ import 'package:happy_day/theme/theme.dart';
 import 'package:onboarding_repository/onboarding_repository.dart';
 import 'package:steps_generation_repository/steps_generation_repository.dart';
 import 'package:structures_repository/structures_repository.dart';
+import 'package:reviews_repository/reviews_repository.dart';
 import 'package:toastification/toastification.dart';
 
 class App extends StatelessWidget {
   const App({
     required this.structuresRepository,
+    required this.reviewsRepository,
     required this.stepsGenerationRepository,
     required this.onboardingRepository,
     required this.emailRepository,
@@ -23,6 +25,7 @@ class App extends StatelessWidget {
   });
 
   final StructuresRepository structuresRepository;
+  final ReviewsRepository reviewsRepository;
   final StepsGenerationRepository stepsGenerationRepository;
   final OnboardingRepository onboardingRepository;
   final EmailRepository emailRepository;
@@ -36,6 +39,9 @@ class App extends StatelessWidget {
         ),
         RepositoryProvider.value(
           value: stepsGenerationRepository,
+        ),
+        RepositoryProvider.value(
+          value: reviewsRepository,
         ),
         RepositoryProvider.value(
           value: onboardingRepository,

--- a/lib/bootstrap.dart
+++ b/lib/bootstrap.dart
@@ -10,10 +10,13 @@ import 'package:path_provider/path_provider.dart';
 import 'package:steps_generation_repository/steps_generation_repository.dart';
 import 'package:structures_api/structures_api.dart';
 import 'package:structures_repository/structures_repository.dart';
+import 'package:reviews_api/reviews_api.dart';
+import 'package:reviews_repository/reviews_repository.dart';
 import 'package:wiredash/wiredash.dart';
 
 Future<void> bootstrap({
   required StructuresApi structuresApi,
+  required ReviewsApi reviewsApi,
   required StepsGenerationRepository stepsGenerationRepository,
   required OnboardingRepository onboardingRepository,
   required void Function(FlutterErrorDetails) onFatalError,
@@ -32,6 +35,7 @@ Future<void> bootstrap({
 
   final structuresRepository =
       StructuresRepository(structuresApi: structuresApi);
+  final reviewsRepository = ReviewsRepository(reviewsApi: reviewsApi);
   const emailRepository = EmailRepository();
 
   if (sendCrashlyticsReports) {
@@ -53,6 +57,7 @@ Future<void> bootstrap({
       secret: wiredashSecret,
       child: App(
         structuresRepository: structuresRepository,
+        reviewsRepository: reviewsRepository,
         stepsGenerationRepository: stepsGenerationRepository,
         onboardingRepository: onboardingRepository,
         emailRepository: emailRepository,

--- a/lib/daily_structures/view/daily_structures_page.dart
+++ b/lib/daily_structures/view/daily_structures_page.dart
@@ -74,6 +74,10 @@ class DailyStructuresView extends StatelessWidget {
         appBar: AppBar(
           actions: [
             IconButton(
+              onPressed: () => context.pushNamed(RoutesNames.weeklyReview),
+              icon: const Icon(Icons.calendar_view_week),
+            ),
+            IconButton(
               onPressed: () => context.pushNamed(RoutesNames.settings),
               icon: const Icon(Icons.settings_outlined),
             ),

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -44,5 +44,18 @@
     "saturdayShort": "Sa",
     "sundayShort": "So",
     "all": "Alle",
-    "weekday": "Wochentag"
+    "weekday": "Wochentag",
+    "weeklyReview": "Wochenrückblick",
+    "weeklyReviewInfo": "Schreibe eine kurze Zusammenfassung deiner Woche",
+    "done": "Erledigt",
+    "inProgress": "In Arbeit",
+    "ongoing": "Laufend",
+    "daysTracked": "Getrackte Tage",
+    "whatIDidGreat": "Was ich toll gemacht habe",
+    "learnings": "Lerninhalte",
+    "start": "Start",
+    "keep": "Beibehalten",
+    "stop": "Stoppen",
+    "weeklyTargets": "Wochenziele",
+    "ok": "OK"
 }

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -44,5 +44,18 @@
     "saturdayShort": "Sa",
     "sundayShort": "Su",
     "all": "All",
-    "weekday": "Weekday"
+    "weekday": "Weekday",
+    "weeklyReview": "Weekly review",
+    "weeklyReviewInfo": "Write a short summary of your week",
+    "done": "Done",
+    "inProgress": "In Progress",
+    "ongoing": "Ongoing",
+    "daysTracked": "Days tracked",
+    "whatIDidGreat": "What I did great",
+    "learnings": "Learnings",
+    "start": "Start",
+    "keep": "Keep",
+    "stop": "Stop",
+    "weeklyTargets": "Weekly targets",
+    "ok": "OK"
 }

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -44,5 +44,18 @@
     "saturdayShort": "Sá",
     "sundayShort": "Do",
     "all": "Todos",
-    "weekday": "Día laborable"
+    "weekday": "Día laborable",
+    "weeklyReview": "Revisión semanal",
+    "weeklyReviewInfo": "Escribe un breve resumen de tu semana",
+    "done": "Hecho",
+    "inProgress": "En progreso",
+    "ongoing": "En curso",
+    "daysTracked": "Días registrados",
+    "whatIDidGreat": "Lo que hice bien",
+    "learnings": "Aprendizajes",
+    "start": "Comenzar",
+    "keep": "Mantener",
+    "stop": "Detener",
+    "weeklyTargets": "Objetivos semanales",
+    "ok": "OK"
 }

--- a/lib/l10n/arb/app_pl.arb
+++ b/lib/l10n/arb/app_pl.arb
@@ -44,5 +44,18 @@
     "saturdayShort": "So",
     "sundayShort": "Ni",
     "all": "Wszystkie",
-    "weekday": "Dzień tygodnia"
+    "weekday": "Dzień tygodnia",
+    "weeklyReview": "Przegląd tygodnia",
+    "weeklyReviewInfo": "Napisz krótkie podsumowanie tygodnia",
+    "done": "Zrobione",
+    "inProgress": "W trakcie",
+    "ongoing": "Trwające",
+    "daysTracked": "Dni śledzone",
+    "whatIDidGreat": "Co zrobiłem świetnie",
+    "learnings": "Nauka",
+    "start": "Start",
+    "keep": "Kontynuuj",
+    "stop": "Zatrzymaj",
+    "weeklyTargets": "Cele tygodnia",
+    "ok": "OK"
 }

--- a/lib/main_development.dart
+++ b/lib/main_development.dart
@@ -6,6 +6,7 @@ import 'package:happy_day/bootstrap.dart';
 import 'package:happy_day/firebase_options_dev.dart';
 import 'package:happy_day/shared/logging.dart';
 import 'package:local_storage_structures_api/local_storage_structures_api.dart';
+import 'package:local_reviews_api/local_reviews_api.dart';
 import 'package:onboarding_repository/onboarding_repository.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:steps_generation_repository/steps_generation_repository.dart';
@@ -22,6 +23,9 @@ Future<void> main() async {
   final structuresApi = LocalStorageStructuresApi(
     plugin: sharedPreferences,
   );
+  final reviewsApi = LocalReviewsApi(
+    plugin: sharedPreferences,
+  );
 
   Bloc.observer = const LoggingBlocObserver();
 
@@ -36,6 +40,7 @@ Future<void> main() async {
 
   return bootstrap(
     structuresApi: structuresApi,
+    reviewsApi: reviewsApi,
     stepsGenerationRepository: stepsGenerationRepository,
     onboardingRepository: onboardingRepository,
     onFatalError: (details) {

--- a/lib/main_production.dart
+++ b/lib/main_production.dart
@@ -7,6 +7,7 @@ import 'package:happy_day/bootstrap.dart';
 import 'package:happy_day/firebase_options_prod.dart';
 import 'package:happy_day/shared/logging.dart';
 import 'package:local_storage_structures_api/local_storage_structures_api.dart';
+import 'package:local_reviews_api/local_reviews_api.dart';
 import 'package:onboarding_repository/onboarding_repository.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:steps_generation_repository/steps_generation_repository.dart';
@@ -21,6 +22,9 @@ Future<void> main() async {
   );
 
   final structuresApi = LocalStorageStructuresApi(
+    plugin: sharedPreferences,
+  );
+  final reviewsApi = LocalReviewsApi(
     plugin: sharedPreferences,
   );
 
@@ -40,6 +44,7 @@ Future<void> main() async {
 
   return bootstrap(
     structuresApi: structuresApi,
+    reviewsApi: reviewsApi,
     stepsGenerationRepository: stepsGenerationRepository,
     onboardingRepository: onboardingRepository,
     onFatalError: FirebaseCrashlytics.instance.recordFlutterFatalError,

--- a/lib/main_staging.dart
+++ b/lib/main_staging.dart
@@ -7,6 +7,7 @@ import 'package:happy_day/bootstrap.dart';
 import 'package:happy_day/firebase_options_stg.dart';
 import 'package:happy_day/shared/logging.dart';
 import 'package:local_storage_structures_api/local_storage_structures_api.dart';
+import 'package:local_reviews_api/local_reviews_api.dart';
 import 'package:onboarding_repository/onboarding_repository.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:steps_generation_repository/steps_generation_repository.dart';
@@ -21,6 +22,9 @@ Future<void> main() async {
   );
 
   final structuresApi = LocalStorageStructuresApi(
+    plugin: sharedPreferences,
+  );
+  final reviewsApi = LocalReviewsApi(
     plugin: sharedPreferences,
   );
 
@@ -40,6 +44,7 @@ Future<void> main() async {
 
   return bootstrap(
     structuresApi: structuresApi,
+    reviewsApi: reviewsApi,
     stepsGenerationRepository: stepsGenerationRepository,
     onboardingRepository: onboardingRepository,
     onFatalError: FirebaseCrashlytics.instance.recordFlutterFatalError,

--- a/lib/shared/router/router.dart
+++ b/lib/shared/router/router.dart
@@ -10,6 +10,7 @@ import 'package:happy_day/onboarding/view/onboarding_page.dart';
 import 'package:happy_day/settings/settings.dart';
 import 'package:happy_day/shared/router/routes_names.dart';
 import 'package:happy_day/structure_details/view/structure_details_page.dart';
+import 'package:happy_day/weekly_review/view/weekly_review_page.dart';
 import 'package:structures_api/structures_api.dart';
 
 part 'routes/daily_structures.dart';
@@ -17,6 +18,7 @@ part 'routes/edit_structure.dart';
 part 'routes/onboarding.dart';
 part 'routes/settings.dart';
 part 'routes/structure_details.dart';
+part 'routes/weekly_review.dart';
 
 final goRouter = GoRouter(
   initialLocation: '/${RoutesNames.onboarding}',
@@ -26,6 +28,7 @@ final goRouter = GoRouter(
     _dailyStructuresRoute,
     _structureDetailsRoute,
     _editStructureRoute,
+    _weeklyReviewRoute,
     _settingsRoute,
   ],
 );

--- a/lib/shared/router/routes/weekly_review.dart
+++ b/lib/shared/router/routes/weekly_review.dart
@@ -1,0 +1,7 @@
+part of '../router.dart';
+
+final _weeklyReviewRoute = GoRoute(
+  name: RoutesNames.weeklyReview,
+  path: '/${RoutesNames.weeklyReview}',
+  builder: (context, state) => const WeeklyReviewPage(),
+);

--- a/lib/shared/router/routes_names.dart
+++ b/lib/shared/router/routes_names.dart
@@ -6,4 +6,5 @@ class RoutesNames {
   static const String editStructure = 'edit-structure';
   static const String structureDetails = 'structure-details';
   static const String settings = 'settings';
+  static const String weeklyReview = 'weekly-review';
 }

--- a/lib/weekly_review/cubit/weekly_review_cubit.dart
+++ b/lib/weekly_review/cubit/weekly_review_cubit.dart
@@ -1,0 +1,186 @@
+import 'dart:async';
+
+import 'package:bloc/bloc.dart';
+import 'package:flutter_fimber/flutter_fimber.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:reviews_repository/reviews_repository.dart';
+import 'package:reviews_api/reviews_api.dart';
+import 'package:structures_repository/structures_repository.dart';
+import 'package:structures_api/structures_api.dart';
+
+part 'weekly_review_cubit.freezed.dart';
+part 'weekly_review_state.dart';
+
+class WeeklyReviewCubit extends Cubit<WeeklyReviewState> {
+  WeeklyReviewCubit({
+    required ReviewsRepository reviewsRepository,
+    required StructuresRepository structuresRepository,
+  })  : _reviewsRepository = reviewsRepository,
+        _structuresRepository = structuresRepository,
+        super(
+          WeeklyReviewState(
+            selectedDate: DateTime.now(),
+            review: null,
+          ),
+        );
+
+  final ReviewsRepository _reviewsRepository;
+  final StructuresRepository _structuresRepository;
+
+  StreamSubscription<List<WeeklyReview>>? _reviewsSub;
+  StreamSubscription<List<StructureOfADay>>? _structuresSub;
+
+  void init() {
+    emit(
+      state.copyWith(
+        reviewStatus: WeeklyReviewStatus.loading,
+        statsStatus: WeeklyReviewStatus.loading,
+      ),
+    );
+
+    _initReviews();
+    _initStructures();
+  }
+
+  void _initReviews() {
+    _reviewsSub?.cancel();
+    _reviewsSub = _reviewsRepository.getWeeklyReviews().listen(
+      (reviews) {
+        final week = _weekNumber(state.selectedDate);
+        final index = reviews.indexWhere(
+          (r) => r.weekNumber == week && r.year == state.selectedDate.year,
+        );
+        final review = index >= 0 ? reviews[index] : null;
+        emit(
+          state.copyWith(
+            review: review,
+            reviewStatus: WeeklyReviewStatus.success,
+          ),
+        );
+      },
+      onError: (error, stack) {
+        Fimber.e('Failed to load weekly reviews', ex: error, stacktrace: stack);
+        emit(state.copyWith(reviewStatus: WeeklyReviewStatus.failure));
+      },
+    );
+  }
+
+  void _initStructures() {
+    _structuresSub?.cancel();
+    _structuresSub = _structuresRepository.getStructuresOfADay().listen(
+      (structuresOfADay) {
+        final from = _startOfWeek(state.selectedDate);
+        final to = from.add(const Duration(days: 6));
+        final weekStructures = structuresOfADay.where(
+          (s) => !s.date.isBefore(from) && !s.date.isAfter(to),
+        );
+
+        var done = 0;
+        var inProgress = 0;
+        final trackedDays = <DateTime>{};
+
+        for (final s in weekStructures) {
+          trackedDays.add(DateTime(s.date.year, s.date.month, s.date.day));
+          if (s.isCompleted) {
+            done++;
+          } else {
+            inProgress++;
+          }
+        }
+
+        emit(
+          state.copyWith(
+            doneCount: done,
+            inProgressCount: inProgress,
+            ongoingCount: 0,
+            daysTracked: trackedDays.length,
+            statsStatus: WeeklyReviewStatus.success,
+          ),
+        );
+      },
+      onError: (error, stack) {
+        Fimber.e('Failed to load structures', ex: error, stacktrace: stack);
+        emit(state.copyWith(statsStatus: WeeklyReviewStatus.failure));
+      },
+    );
+
+    final from = _startOfWeek(state.selectedDate);
+    for (var i = 0; i < 7; i++) {
+      _structuresRepository.loadStructuresOfADay(from.add(Duration(days: i)));
+    }
+  }
+
+  int _weekNumber(DateTime date) {
+    final firstThursday = DateTime(date.year, 1, 4);
+    final diff = date.difference(firstThursday.subtract(Duration(days: firstThursday.weekday - 1)));
+    return 1 + diff.inDays ~/ 7;
+  }
+
+  int weekNumberFor(DateTime date) => _weekNumber(date);
+
+  Future<void> previousWeek() async {
+    final newDate = state.selectedDate.subtract(const Duration(days: 7));
+    emit(
+      state.copyWith(
+        selectedDate: newDate,
+        reviewStatus: WeeklyReviewStatus.loading,
+        statsStatus: WeeklyReviewStatus.loading,
+      ),
+    );
+    init();
+  }
+
+  Future<void> nextWeek() async {
+    final newDate = state.selectedDate.add(const Duration(days: 7));
+    emit(
+      state.copyWith(
+        selectedDate: newDate,
+        reviewStatus: WeeklyReviewStatus.loading,
+        statsStatus: WeeklyReviewStatus.loading,
+      ),
+    );
+    init();
+  }
+
+  Future<void> saveReview({
+    String? whatIDidGreat,
+    String? learnings,
+    String? start,
+    String? keep,
+    String? stop,
+    String? weeklyTargets,
+  }) async {
+    final existing = state.review ??
+        WeeklyReview(
+          weekNumber: _weekNumber(state.selectedDate),
+          year: state.selectedDate.year,
+        );
+
+    final updated = existing.copyWith(
+      whatIDidGreat: whatIDidGreat ?? existing.whatIDidGreat,
+      learnings: learnings ?? existing.learnings,
+      start: start ?? existing.start,
+      keep: keep ?? existing.keep,
+      stop: stop ?? existing.stop,
+      weeklyTargets: weeklyTargets ?? existing.weeklyTargets,
+    );
+
+    await _reviewsRepository.saveWeeklyReview(updated);
+
+    emit(state.copyWith(review: updated));
+  }
+
+  DateTime _startOfWeek(DateTime date) {
+    final jan4 = DateTime(date.year, 1, 4);
+    final firstMonday = jan4.subtract(Duration(days: jan4.weekday - 1));
+    final week = _weekNumber(date);
+    return firstMonday.add(Duration(days: 7 * (week - 1)));
+  }
+
+  @override
+  Future<void> close() {
+    _reviewsSub?.cancel();
+    _structuresSub?.cancel();
+    return super.close();
+  }
+}

--- a/lib/weekly_review/cubit/weekly_review_cubit.freezed.dart
+++ b/lib/weekly_review/cubit/weekly_review_cubit.freezed.dart
@@ -1,0 +1,1 @@
+// TODO: Generated code - placeholder

--- a/lib/weekly_review/cubit/weekly_review_state.dart
+++ b/lib/weekly_review/cubit/weekly_review_state.dart
@@ -1,0 +1,23 @@
+part of 'weekly_review_cubit.dart';
+
+enum WeeklyReviewStatus { initial, loading, success, failure }
+
+@freezed
+class WeeklyReviewState with _$WeeklyReviewState {
+  const factory WeeklyReviewState({
+    required DateTime selectedDate,
+    WeeklyReview? review,
+    @Default(WeeklyReviewStatus.initial) WeeklyReviewStatus reviewStatus,
+    @Default(WeeklyReviewStatus.initial) WeeklyReviewStatus statsStatus,
+    @Default(0) int doneCount,
+    @Default(0) int inProgressCount,
+    @Default(0) int ongoingCount,
+    @Default(0) int daysTracked,
+  }) = _WeeklyReviewState;
+
+  const WeeklyReviewState._();
+
+  bool get isLoading =>
+      reviewStatus == WeeklyReviewStatus.loading ||
+      statsStatus == WeeklyReviewStatus.loading;
+}

--- a/lib/weekly_review/view/weekly_review_page.dart
+++ b/lib/weekly_review/view/weekly_review_page.dart
@@ -1,0 +1,344 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:happy_day/l10n/l10n.dart';
+import 'package:happy_day/shared/toastification.dart';
+import 'package:happy_day/shared/widgets/sliver_delegate.dart';
+import 'package:reviews_repository/reviews_repository.dart';
+import 'package:structures_repository/structures_repository.dart';
+import 'package:intl/intl.dart';
+import 'package:easy_date_timeline/easy_date_timeline.dart';
+import 'package:skeletonizer/skeletonizer.dart';
+
+import '../weekly_review.dart';
+
+class WeeklyReviewPage extends StatelessWidget {
+  const WeeklyReviewPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider(
+      create: (_) => WeeklyReviewCubit(
+        reviewsRepository: context.read<ReviewsRepository>(),
+        structuresRepository: context.read<StructuresRepository>(),
+      )..init(),
+      child: const WeeklyReviewView(),
+    );
+  }
+}
+
+class WeeklyReviewView extends StatelessWidget {
+  const WeeklyReviewView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocListener<WeeklyReviewCubit, WeeklyReviewState>(
+      listenWhen: (previous, current) =>
+          previous.reviewStatus != current.reviewStatus ||
+          previous.statsStatus != current.statsStatus,
+      listener: (context, state) {
+        if (state.reviewStatus == WeeklyReviewStatus.failure ||
+            state.statsStatus == WeeklyReviewStatus.failure) {
+          showErrorToastification(title: context.l10n.errorMessage);
+        }
+      },
+      child: Scaffold(
+        appBar: AppBar(
+          centerTitle: true,
+          title: Text(context.l10n.weeklyReview),
+        ),
+        body: const SafeArea(
+          child: WeeklyReviewContent(),
+        ),
+      ),
+    );
+  }
+}
+
+class WeeklyReviewContent extends StatelessWidget {
+  const WeeklyReviewContent({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final cubit = context.watch<WeeklyReviewCubit>();
+    final state = cubit.state;
+    final l10n = context.l10n;
+    final weekNumber = cubit.weekNumberFor(state.selectedDate);
+    final reviewTemplate = WeeklyReview(weekNumber: weekNumber, year: state.selectedDate.year);
+    final review = state.review ?? reviewTemplate;
+    final dateFormat = DateFormat(const DateFormatter.fullDateDMonthAsStrY().format());
+
+    return CustomScrollView(
+      slivers: [
+        SliverPersistentHeader(
+          pinned: true,
+          delegate: SliverDelegate(
+            minHeight: 100,
+            maxHeight: 100,
+            child: ColoredBox(
+              color: Theme.of(context).colorScheme.surface,
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 10),
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Row(
+                          children: [
+                            Text(l10n.weeklyReview),
+                            IconButton(
+                              icon: const Icon(Icons.info_outline),
+                          onPressed: () {
+                            showDialog(
+                              context: context,
+                              builder: (_) => AlertDialog(
+                                content: Text(l10n.weeklyReviewInfo),
+                                actions: [
+                                  TextButton(
+                                    onPressed: () => Navigator.pop(context),
+                                    child: Text(l10n.ok),
+                                  ),
+                                ],
+                              ),
+                            );
+                          },
+                        ),
+                      ],
+                      ],
+                    ),
+                    Text(
+                      '${dateFormat.format(review.fromDate)} - ${dateFormat.format(review.toDate)}',
+                    ),
+                  ),
+                  Row(
+                    children: [
+                      IconButton(
+                        onPressed: cubit.previousWeek,
+                        icon: const Icon(Icons.chevron_left),
+                      ),
+                      IconButton(
+                        onPressed: cubit.nextWeek,
+                        icon: const Icon(Icons.chevron_right),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+        SliverToBoxAdapter(
+          child: Padding(
+            padding: const EdgeInsets.all(8),
+            child: GridView.count(
+              crossAxisCount: 2,
+              shrinkWrap: true,
+              childAspectRatio: 3,
+              physics: const NeverScrollableScrollPhysics(),
+              children: [
+                _StatsCard(
+                  number: state.doneCount,
+                  label: l10n.done,
+                  isLoading: state.statsStatus != WeeklyReviewStatus.success,
+                ),
+                _StatsCard(
+                  number: state.inProgressCount,
+                  label: l10n.inProgress,
+                  isLoading: state.statsStatus != WeeklyReviewStatus.success,
+                ),
+                _StatsCard(
+                  number: state.ongoingCount,
+                  label: l10n.ongoing,
+                  isLoading: state.statsStatus != WeeklyReviewStatus.success,
+                ),
+                _StatsCard(
+                  number: state.daysTracked,
+                  label: l10n.daysTracked,
+                  isLoading: state.statsStatus != WeeklyReviewStatus.success,
+                ),
+              ],
+            ),
+          ),
+        ),
+        SliverToBoxAdapter(
+          child: Padding(
+            padding: const EdgeInsets.all(8),
+            child: Column(
+              children: [
+                _ReviewField(
+                  label: l10n.whatIDidGreat,
+                  initialValue: review.whatIDidGreat,
+                  isLoading:
+                      state.reviewStatus != WeeklyReviewStatus.success,
+                  onSaved: (value) =>
+                      cubit.saveReview(whatIDidGreat: value),
+                ),
+                _ReviewField(
+                  label: l10n.learnings,
+                  initialValue: review.learnings,
+                  isLoading:
+                      state.reviewStatus != WeeklyReviewStatus.success,
+                  onSaved: (value) => cubit.saveReview(learnings: value),
+                ),
+                _ReviewField(
+                  label: l10n.start,
+                  initialValue: review.start,
+                  isLoading:
+                      state.reviewStatus != WeeklyReviewStatus.success,
+                  onSaved: (value) => cubit.saveReview(start: value),
+                ),
+                _ReviewField(
+                  label: l10n.keep,
+                  initialValue: review.keep,
+                  isLoading:
+                      state.reviewStatus != WeeklyReviewStatus.success,
+                  onSaved: (value) => cubit.saveReview(keep: value),
+                ),
+                _ReviewField(
+                  label: l10n.stop,
+                  initialValue: review.stop,
+                  isLoading:
+                      state.reviewStatus != WeeklyReviewStatus.success,
+                  onSaved: (value) => cubit.saveReview(stop: value),
+                ),
+                _ReviewField(
+                  label: l10n.weeklyTargets,
+                  initialValue: review.weeklyTargets,
+                  isLoading:
+                      state.reviewStatus != WeeklyReviewStatus.success,
+                  onSaved: (value) => cubit.saveReview(weeklyTargets: value),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _StatsCard extends StatelessWidget {
+  const _StatsCard({
+    required this.number,
+    required this.label,
+    this.isLoading = false,
+  });
+
+  final int number;
+  final String label;
+  final bool isLoading;
+
+  @override
+  Widget build(BuildContext context) {
+    final child = Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          FittedBox(
+            fit: BoxFit.scaleDown,
+            child: Text(
+              '$number',
+              style: Theme.of(context).textTheme.headlineSmall,
+            ),
+          ),
+          const SizedBox(height: 4),
+          FittedBox(
+            fit: BoxFit.scaleDown,
+            child: Text(label, textAlign: TextAlign.center),
+          ),
+        ],
+      ),
+    );
+
+    return Card(
+      child: Skeletonizer(
+        enabled: isLoading,
+        child: Padding(
+          padding: const EdgeInsets.all(8),
+          child: child,
+        ),
+      ),
+    );
+  }
+}
+
+class _ReviewField extends StatelessWidget {
+  const _ReviewField({
+    required this.label,
+    required this.initialValue,
+    required this.onSaved,
+    required this.isLoading,
+  });
+
+  final String label;
+  final String initialValue;
+  final ValueChanged<String> onSaved;
+  final bool isLoading;
+
+  @override
+  Widget build(BuildContext context) {
+    final color = Theme.of(context).colorScheme.primary;
+
+    final decoration = InputDecoration(
+      labelText: label,
+      floatingLabelBehavior: FloatingLabelBehavior.always,
+      labelStyle: TextStyle(color: color),
+      enabledBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(10),
+        borderSide: BorderSide(color: color),
+      ),
+      focusedBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(10),
+        borderSide: BorderSide(color: color),
+      ),
+      filled: true,
+      fillColor: color.withOpacity(0.025),
+    );
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      child: Skeletonizer(
+        enabled: isLoading,
+        child: TextField(
+          controller: TextEditingController(text: initialValue),
+          readOnly: true,
+          decoration: decoration,
+          onTap: () {
+            final controller = TextEditingController(text: initialValue);
+            showDialog(
+              context: context,
+              builder: (context) {
+                return AlertDialog(
+                  content: SizedBox(
+                    height: MediaQuery.of(context).size.height * 0.6,
+                    child: TextField(
+                      controller: controller,
+                      maxLines: null,
+                      expands: true,
+                      decoration: decoration,
+                    ),
+                  ),
+                  actions: [
+                    TextButton(
+                      onPressed: () => Navigator.pop(context),
+                      child: Text(MaterialLocalizations.of(context).cancelButtonLabel),
+                    ),
+                    TextButton(
+                      onPressed: () {
+                        onSaved(controller.text);
+                        Navigator.pop(context);
+                      },
+                      child: Text(MaterialLocalizations.of(context).okButtonLabel),
+                    ),
+                  ],
+                );
+              },
+            );
+          },
+        ),
+      ),
+    );
+  }
+}

--- a/lib/weekly_review/weekly_review.dart
+++ b/lib/weekly_review/weekly_review.dart
@@ -1,0 +1,2 @@
+export 'cubit/weekly_review_cubit.dart';
+export 'view/weekly_review_page.dart';

--- a/packages/local_reviews_api/lib/local_reviews_api.dart
+++ b/packages/local_reviews_api/lib/local_reviews_api.dart
@@ -1,0 +1,4 @@
+/// A Flutter implementation of the ReviewsApi that uses local storage.
+library;
+
+export 'src/local_reviews_api.dart';

--- a/packages/local_reviews_api/lib/src/local_reviews_api.dart
+++ b/packages/local_reviews_api/lib/src/local_reviews_api.dart
@@ -1,0 +1,84 @@
+import 'dart:convert';
+
+import 'package:meta/meta.dart';
+import 'package:rxdart/subjects.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:reviews_api/reviews_api.dart';
+
+/// {@template local_reviews_api}
+/// A Flutter implementation of the ReviewsApi that uses local storage.
+/// {@endtemplate}
+class LocalReviewsApi extends ReviewsApi {
+  /// {@macro local_reviews_api}
+  LocalReviewsApi({required SharedPreferences plugin}) : _plugin = plugin {
+    _init();
+  }
+
+  final SharedPreferences _plugin;
+
+  late final _reviewsStreamController =
+      BehaviorSubject<List<WeeklyReview>>.seeded(const []);
+
+  /// The key used for storing the reviews locally.
+  ///
+  /// This is only exposed for testing and shouldn't be used by consumers of
+  /// this library.
+  @visibleForTesting
+  static const kReviewsCollectionKey = '__reviews_collection_key__';
+
+  String? _getValue(String key) => _plugin.getString(key);
+  Future<void> _setValue(String key, String value) => _plugin.setString(key, value);
+
+  void _init() {
+    final reviewsJson = _getValue(kReviewsCollectionKey);
+    if (reviewsJson != null) {
+      final reviews = List<Map<dynamic, dynamic>>.from(
+        json.decode(reviewsJson) as List,
+      )
+          .map((jsonMap) =>
+              WeeklyReview.fromJson(Map<String, dynamic>.from(jsonMap)))
+          .toList();
+      _reviewsStreamController.add(reviews);
+    } else {
+      _reviewsStreamController.add(const []);
+    }
+  }
+
+  @override
+  Stream<List<WeeklyReview>> getWeeklyReviews() =>
+      _reviewsStreamController.asBroadcastStream();
+
+  @override
+  Future<void> saveWeeklyReview(WeeklyReview review) async {
+    final reviews = [..._reviewsStreamController.value];
+    final index = reviews.indexWhere(
+      (r) => r.weekNumber == review.weekNumber && r.year == review.year,
+    );
+    if (index >= 0) {
+      reviews[index] = review;
+    } else {
+      reviews.add(review);
+    }
+    _reviewsStreamController.add(reviews);
+    await _setValue(kReviewsCollectionKey, json.encode(reviews));
+  }
+
+  @override
+  Future<void> deleteWeeklyReview(int weekNumber, int year) async {
+    final reviews = [..._reviewsStreamController.value];
+    final index = reviews.indexWhere(
+      (r) => r.weekNumber == weekNumber && r.year == year,
+    );
+    if (index == -1) {
+      throw WeeklyReviewNotFoundException();
+    }
+    reviews.removeAt(index);
+    _reviewsStreamController.add(reviews);
+    await _setValue(kReviewsCollectionKey, json.encode(reviews));
+  }
+
+  @override
+  Future<void> close() async {
+    await _reviewsStreamController.close();
+  }
+}

--- a/packages/local_reviews_api/pubspec.yaml
+++ b/packages/local_reviews_api/pubspec.yaml
@@ -1,0 +1,24 @@
+name: local_reviews_api
+description: A Flutter implementation of the ReviewsApi that uses local storage.
+version: 0.1.0+1
+publish_to: none
+
+environment:
+  sdk: ^3.6.1
+  flutter: ^3.27.2
+
+dependencies:
+  flutter:
+    sdk: flutter
+  meta: ^1.15.0
+  rxdart: ^0.28.0
+  shared_preferences: ^2.3.5
+  reviews_api:
+    path: ../reviews_api
+
+dev_dependencies:
+  build_runner: ^2.4.14
+  flutter_test:
+    sdk: flutter
+  mocktail: ^1.0.4
+  very_good_analysis: ^6.0.0

--- a/packages/reviews_api/lib/reviews_api.dart
+++ b/packages/reviews_api/lib/reviews_api.dart
@@ -1,0 +1,5 @@
+/// The interface and models for an API providing access to weekly reviews.
+library;
+
+export 'src/reviews_api.dart';
+export 'src/models/models.dart';

--- a/packages/reviews_api/lib/src/models/models.dart
+++ b/packages/reviews_api/lib/src/models/models.dart
@@ -1,0 +1,1 @@
+export 'weekly_review.dart';

--- a/packages/reviews_api/lib/src/models/weekly_review.dart
+++ b/packages/reviews_api/lib/src/models/weekly_review.dart
@@ -1,0 +1,36 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'weekly_review.freezed.dart';
+part 'weekly_review.g.dart';
+
+/// A review of a specific week of a year.
+@freezed
+class WeeklyReview with _$WeeklyReview {
+  /// Creates a new [WeeklyReview].
+  factory WeeklyReview({
+    required int weekNumber,
+    required int year,
+    @Default('') String whatIDidGreat,
+    @Default('') String learnings,
+    @Default('') String start,
+    @Default('') String keep,
+    @Default('') String stop,
+    @Default('') String weeklyTargets,
+  }) = _WeeklyReview;
+
+  WeeklyReview._();
+
+  /// Creates a new [WeeklyReview] from a JSON object.
+  factory WeeklyReview.fromJson(Map<String, Object?> json) =>
+      _$WeeklyReviewFromJson(json);
+
+  /// Returns the first day date of this review week.
+  DateTime get fromDate {
+    final jan4 = DateTime(year, 1, 4);
+    final firstMonday = jan4.subtract(Duration(days: jan4.weekday - 1));
+    return firstMonday.add(Duration(days: 7 * (weekNumber - 1)));
+  }
+
+  /// Returns the last day date of this review week.
+  DateTime get toDate => fromDate.add(const Duration(days: 6));
+}

--- a/packages/reviews_api/lib/src/models/weekly_review.freezed.dart
+++ b/packages/reviews_api/lib/src/models/weekly_review.freezed.dart
@@ -1,0 +1,1 @@
+// TODO: Generated code - placeholder

--- a/packages/reviews_api/lib/src/models/weekly_review.g.dart
+++ b/packages/reviews_api/lib/src/models/weekly_review.g.dart
@@ -1,0 +1,1 @@
+// TODO: Generated code - placeholder

--- a/packages/reviews_api/lib/src/reviews_api.dart
+++ b/packages/reviews_api/lib/src/reviews_api.dart
@@ -1,0 +1,25 @@
+import 'package:reviews_api/reviews_api.dart';
+
+/// {@template reviews_api}
+/// The interface for an API that provides access to weekly reviews.
+/// {@endtemplate}
+abstract class ReviewsApi {
+  /// {@macro reviews_api}
+  const ReviewsApi();
+
+  /// Provides a stream of all weekly reviews.
+  Stream<List<WeeklyReview>> getWeeklyReviews();
+
+  /// Saves a [review]. If a review for the same week already exists, it
+  /// will be replaced.
+  Future<void> saveWeeklyReview(WeeklyReview review);
+
+  /// Deletes the review for the given [weekNumber] and [year].
+  Future<void> deleteWeeklyReview(int weekNumber, int year);
+
+  /// Closes the underlying resources.
+  Future<void> close();
+}
+
+/// Error thrown when a review for a given week is not found.
+class WeeklyReviewNotFoundException implements Exception {}

--- a/packages/reviews_api/pubspec.yaml
+++ b/packages/reviews_api/pubspec.yaml
@@ -1,0 +1,20 @@
+name: reviews_api
+description: The interface and models for an API providing access to weekly reviews.
+version: 0.1.0+1
+publish_to: none
+
+environment:
+  sdk: ^3.6.1
+
+dependencies:
+  freezed_annotation: ^2.4.4
+  json_annotation: ^4.9.0
+
+
+dev_dependencies:
+  build_runner: ^2.4.14
+  freezed: ^2.5.8
+  json_serializable: ^6.9.3
+  mocktail: ^1.0.4
+  test: ^1.25.8
+  very_good_analysis: ^6.0.0

--- a/packages/reviews_repository/lib/reviews_repository.dart
+++ b/packages/reviews_repository/lib/reviews_repository.dart
@@ -1,0 +1,4 @@
+/// A repository that handles weekly reviews related requests.
+library;
+
+export 'src/reviews_repository.dart';

--- a/packages/reviews_repository/lib/src/reviews_repository.dart
+++ b/packages/reviews_repository/lib/src/reviews_repository.dart
@@ -1,0 +1,23 @@
+import 'package:reviews_api/reviews_api.dart';
+
+/// {@template reviews_repository}
+/// A repository that handles weekly reviews related requests.
+/// {@endtemplate}
+class ReviewsRepository {
+  /// {@macro reviews_repository}
+  const ReviewsRepository({required ReviewsApi reviewsApi})
+      : _reviewsApi = reviewsApi;
+
+  final ReviewsApi _reviewsApi;
+
+  /// Provides a [Stream] of weekly reviews.
+  Stream<List<WeeklyReview>> getWeeklyReviews() => _reviewsApi.getWeeklyReviews();
+
+  /// Saves a [review].
+  Future<void> saveWeeklyReview(WeeklyReview review) =>
+      _reviewsApi.saveWeeklyReview(review);
+
+  /// Deletes a review.
+  Future<void> deleteWeeklyReview(int weekNumber, int year) =>
+      _reviewsApi.deleteWeeklyReview(weekNumber, year);
+}

--- a/packages/reviews_repository/pubspec.yaml
+++ b/packages/reviews_repository/pubspec.yaml
@@ -1,0 +1,17 @@
+name: reviews_repository
+description: A repository that handles weekly reviews related requests.
+version: 0.1.0+1
+publish_to: none
+
+environment:
+  sdk: ^3.6.1
+
+dependencies:
+  reviews_api:
+    path: ../reviews_api
+
+
+dev_dependencies:
+  mocktail: ^1.0.4
+  test: ^1.25.8
+  very_good_analysis: ^6.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -46,6 +46,12 @@ dependencies:
     path: packages/structures_api
   structures_repository:
     path: packages/structures_repository
+  reviews_api:
+    path: packages/reviews_api
+  reviews_repository:
+    path: packages/reviews_repository
+  local_reviews_api:
+    path: packages/local_reviews_api
   toastification: ^2.3.0
   wiredash: ^2.4.0
 


### PR DESCRIPTION
## Summary
- add packages for reviews API, repository and local storage
- create WeeklyReview page with cubit and UI widgets
- wire up a new weekly review route
- provide reviews repository to the app
- add navigation button from daily structures page
- update localization files
- improve weekly review cubit with stats loading and saving
- polish review header, stats cards and fields

## Testing
- `flutter test` *(fails: command not found)*